### PR TITLE
Fixed folders not being created when building repo

### DIFF
--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ if not os.path.exists("bin"):
 cwd = os.getcwd()
 run("rm obj/*.o")
 run("rm bin/*.elf")
-print(CC+  " -Os -s  -g -I include -I include/libntrplg " + allFile('source/libntrplg/*.c') + allFile('source/ns/*.c') + allFile('source/*.c') + allFile('source/battle/*.c') + allFile('source/rng/*.c') + allFile('source/libctru/*.c') + " -c  -march=armv6 -mlittle-endian ");
+run(CC+  " -Os -s  -g -I include -I include/libntrplg " + allFile('source/libntrplg/*.c') + allFile('source/ns/*.c') + allFile('source/*.c') + allFile('source/battle/*.c') + allFile('source/rng/*.c') + allFile('source/libctru/*.c') + " -c  -march=armv6 -mlittle-endian ");
 run(CC+"  -Os " + allFile('source/libntrplg/*.s') +  allFile('source/ns/*.s')  + allFile('source/*.s') + allFile('source/libctru/*.s') + " -c -s -march=armv6 -mlittle-endian ");
 
 run(LD + ' ' + LIBPATH + " -pie --print-gc-sections  -T 3ds.ld -Map=homebrew.map " + allFile("*.o") + " " + allFile("lib/*.o") + " " + allFile("lib/*.a") + " -lc --nostdlib")

--- a/build.py
+++ b/build.py
@@ -26,10 +26,16 @@ def run(cmd):
 	#print(cmd);
 	os.system(cmd)
 
+# Check if required folders exist
+if not os.path.exists("obj"):
+    os.makedirs("obj");
+if not os.path.exists("bin"):
+    os.makedirs("bin");
+
 cwd = os.getcwd()
 run("rm obj/*.o")
 run("rm bin/*.elf")
-run(CC+  " -Os -s  -g -I include -I include/libntrplg " + allFile('source/libntrplg/*.c') + allFile('source/ns/*.c') + allFile('source/*.c') + allFile('source/battle/*.c') + allFile('source/rng/*.c') + allFile('source/libctru/*.c') + " -c  -march=armv6 -mlittle-endian  ");
+print(CC+  " -Os -s  -g -I include -I include/libntrplg " + allFile('source/libntrplg/*.c') + allFile('source/ns/*.c') + allFile('source/*.c') + allFile('source/battle/*.c') + allFile('source/rng/*.c') + allFile('source/libctru/*.c') + " -c  -march=armv6 -mlittle-endian ");
 run(CC+"  -Os " + allFile('source/libntrplg/*.s') +  allFile('source/ns/*.s')  + allFile('source/*.s') + allFile('source/libctru/*.s') + " -c -s -march=armv6 -mlittle-endian ");
 
 run(LD + ' ' + LIBPATH + " -pie --print-gc-sections  -T 3ds.ld -Map=homebrew.map " + allFile("*.o") + " " + allFile("lib/*.o") + " " + allFile("lib/*.a") + " -lc --nostdlib")


### PR DESCRIPTION
Added a missing feature that caused building to fail of no folders are created.
Fixed this by automatically detecting if the folders are present, and if not, creating them.